### PR TITLE
Enhance logging and error handling in input processing; update OpenAI…

### DIFF
--- a/bin/format_input.py
+++ b/bin/format_input.py
@@ -126,11 +126,12 @@ def select_img_groups(file_groups: dict, test_image_names: str, test_image_count
         group_ids = np.random.choice(list(file_groups.keys()), test_image_count, replace=False)
     elif test_image_names is not None:
         # select specific image groups to process
-        logging.info("Selecting specific image groups")
+        logging.info("Selecting specific image groups based on --test-image-names")
         test_image_names = [str(x).strip() for x in test_image_names.split(',')]
         group_ids = [x for x in file_groups.keys() if x in test_image_names]
         if len(group_ids) == 0:
-            raise ValueError("No matching image groups found")
+            file_groups_str = ', '.join(file_groups.keys())
+            raise ValueError(f"No matching image groups found. Available groups: {file_groups_str}")
     # group files by basename
     if group_ids is not None:
         file_groups = {k: v for k, v in file_groups.items() if k in group_ids}

--- a/envs/summary.yml
+++ b/envs/summary.yml
@@ -6,4 +6,4 @@ dependencies:
   - python=3.11.9
   - pip=24.0
   - markdown=3.6
-  - openai=1.38.0
+  - openai=1.58

--- a/workflows/caiman.nf
+++ b/workflows/caiman.nf
@@ -55,7 +55,7 @@ process CALC_DFF_F0 {
       $cnm_idx \\
       $img_orig \\
       $img_masks \\
-      > ${img_masked.baseName}_calc-diff-f0.log 2>&1
+      2>&1 | tee ${img_masked.baseName}_calc-diff-f0.log
     """
     
     stub:
@@ -127,7 +127,7 @@ process CAIMAN {
       --min_pnr $params.min_pnr \\
       --ring_size_factor $params.ring_size_factor \\
       $frate $img_masked \\
-      > ${img_masked.baseName}_caiman.log 2>&1
+      2>&1 | tee ${img_masked.baseName}_caiman.log
     """
 
     stub:
@@ -142,15 +142,3 @@ process CAIMAN {
       ${img_masked.baseName}_caiman.log
     """
 }
-
-/*
-    path "caiman_output/*_cn_filter.npy"
-    path "caiman_output/*_cn_filter.tif"
-    path "caiman_output/*_cnm_C.npy"
-    path "caiman_output/*_cnm_S.npy"
-    path "caiman_output/*_cnm_idx.npy"
-    path "caiman_output/*_pnr_filter.npy"
-    path "caiman_output/*_masked_pnr_filter.tif"
-    path "caiman_output/correlation_pnr.png"
-    path "caiman_output/histogram_pnr_cn_filter.png"
-*/

--- a/workflows/input.nf
+++ b/workflows/input.nf
@@ -64,7 +64,7 @@ process MOLDEV_CONCAT {
     concatenate_moldev_files.py \\
       --output output/${baseName}_full.tif \\
       $imagePaths \\
-      > ${baseName}_moldev-cat.log 2>&1
+      2>&1 | tee ${baseName}_moldev-cat.log
     """
 
     stub:
@@ -91,7 +91,7 @@ process FORMAT_INPUT{
     format_input.py $test_image_names $test_image_count \\
       --file-type $params.file_type \\
       $input_dir \\
-      > format_input.log 2>&1
+      2>&1 | tee format_input.log
     """
 
     stub:

--- a/workflows/mask.nf
+++ b/workflows/mask.nf
@@ -50,7 +50,8 @@ process MASK {
     export CELLPOSE_LOCAL_MODELS_PATH=models
     # run cellpose
     mask.py --file-type ${params.file_type} ${use_2d_str} \\
-      ${img_file} > ${img_basename}_mask.log 2>&1
+      ${img_file} \\
+      2>&1 | tee ${img_basename}_mask.log
     """
 
     stub:

--- a/workflows/summary.nf
+++ b/workflows/summary.nf
@@ -78,7 +78,7 @@ process WIZARDS_STAFF {
       --zscore-threshold ${params.zscore_threshold} \\
       --output-dir output \\
       ${params.output_dir} \\
-      > wizards-staff.log 2>&1
+      2>&1 | tee wizards-staff.log
     """
 }
 


### PR DESCRIPTION
tl;dr -> output now written to log files *and* terminal for each job in order to better identify errors for failed jobs. 

This pull request includes multiple changes to various workflow files to improve logging and update dependencies. The key changes involve redirecting logs to both the console and log files using `tee`, and updating the `openai` dependency version.

### Dependency Update:
* [`envs/summary.yml`](diffhunk://#diff-7103f1d80b9649b18ed9a547a589233e1bd946b26bb71ae3c919750b9d56ef69L9-R9): Updated `openai` dependency from version `1.38.0` to `1.58`.

### Logging Improvements:
* [`workflows/caiman.nf`](diffhunk://#diff-a24ffc159720f36ad7d919e6bcc5d591474ba4e29f8a6fcd3dba152ff173650eL58-R58): Modified `CALC_DFF_F0` and `CAIMAN` processes to use `2>&1 | tee` for logging to both console and log files. [[1]](diffhunk://#diff-a24ffc159720f36ad7d919e6bcc5d591474ba4e29f8a6fcd3dba152ff173650eL58-R58) [[2]](diffhunk://#diff-a24ffc159720f36ad7d919e6bcc5d591474ba4e29f8a6fcd3dba152ff173650eL130-R130)
* [`workflows/input.nf`](diffhunk://#diff-e946a15a09ad1586cfd1e400f3dfd3c9bf26d81d8f0c71e717cbb2f2a97bf6b4L67-R67): Updated `MOLDEV_CONCAT` and `FORMAT_INPUT` processes to use `2>&1 | tee` for logging. [[1]](diffhunk://#diff-e946a15a09ad1586cfd1e400f3dfd3c9bf26d81d8f0c71e717cbb2f2a97bf6b4L67-R67) [[2]](diffhunk://#diff-e946a15a09ad1586cfd1e400f3dfd3c9bf26d81d8f0c71e717cbb2f2a97bf6b4L94-R94)
* [`workflows/mask.nf`](diffhunk://#diff-e596dee7222d1c0d7de2abf0da3aac9f15803c8c87a2bb29e21a75d07a375bc4L53-R54): Changed `MASK` process to redirect logs using `2>&1 | tee`.
* [`workflows/summary.nf`](diffhunk://#diff-46ae7b732628e6b1f90c63a0f34ee2a7a8845e7d9ea8540595db7472fa83ba80L81-R81): Updated `WIZARDS_STAFF` process to use `2>&1 | tee` for logging.