### PR TITLE
feat: enhance object segmentation with retry logic and parameter config

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -28,6 +28,8 @@ params {
   size_threshold    = 20000         // Size threshold for filtering out noise events.
   percentage_threshold = 0.2        //  Percentage threshold for FWHM calculation.
   zscore_threshold  = 3             // Z-score threshold for filtering out noise events.
+  min_object_size   = 500           // Minimum size of objects in pixels for successful segmentation
+  max_segment_retries = 3           // Maximum number of retries for segmentation if objects are below the threshold
 }
 
 // working directory (-work-dir)

--- a/workflows/mask.nf
+++ b/workflows/mask.nf
@@ -50,8 +50,10 @@ process MASK {
     export CELLPOSE_LOCAL_MODELS_PATH=models
     # run cellpose
     mask.py --file-type ${params.file_type} ${use_2d_str} \\
-      ${img_file} \\
-      2>&1 | tee ${img_basename}_mask.log
+            --min-object-size ${params.min_object_size} \\
+            --max-segment-retries ${params.max_segment_retries} \\
+            ${img_file} \\
+            2>&1 | tee ${img_basename}_mask.log
     """
 
     stub:


### PR DESCRIPTION
- **Updates to `bin/mask.py`:**
  - Added `--min-object-size` and `--max-segment-retries` args to configure segmentation size thresholds and retry numbers.
  - Enhanced `mask_image` function:
    - Introduced retry logic for segmentation if objects are below the size threshold.
    - Integrated `detect_object_sizes` function to evaluate object sizes in masks.
    - Log information about segmentation attempts and outcomes.
  - Added `detect_object_sizes` function to calculate object sizes using `scipy.ndimage`.
  - Improved error handling and logging for segmentation failures.

- **Changes to `nextflow.config`:**
  - Added `min_object_size` and `max_segment_retries` parameters for pipeline configuration.

- **Updates to `workflows/mask.nf`:**
  - Incorporated parameters `--min-object-size` and `--max-segment-retries` in the `MASK` process.

These enhancements improve segmentation by allowing multiple attempts to meet object size thresholds and provide better configurability for diverse datasets. This should allow us to circumvent the Inf NaN errors  that Sneha was encountering, we might want to adjust the preset values based on Sneha's input.